### PR TITLE
Use SeriouslyCommonLib for rotation as well

### DIFF
--- a/src/main/java/competition/subsystems/drive/commands/TurnLeft90DegreesCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/TurnLeft90DegreesCommand.java
@@ -2,16 +2,18 @@ package competition.subsystems.drive.commands;
 
 import javax.inject.Inject;
 
+import xbot.common.math.PIDManager.PIDManagerFactory;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
+import xbot.common.subsystems.drive.control_logic.HeadingModule.HeadingModuleFactory;
 import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.pose.PoseSubsystem;
 
 public class TurnLeft90DegreesCommand extends DriveToOrientationCommand {
 
     @Inject
-    public TurnLeft90DegreesCommand(DriveSubsystem driveSubsystem, PoseSubsystem pose, PropertyFactory propertyFactory) {
-        super(driveSubsystem, pose, propertyFactory);
+    public TurnLeft90DegreesCommand(DriveSubsystem driveSubsystem, PoseSubsystem pose, HeadingModuleFactory headingModuleFactory, PIDManagerFactory pidManagerFactory) {
+        super(driveSubsystem, pose, headingModuleFactory, pidManagerFactory);
     }
 
     @Override


### PR DESCRIPTION
# What's changing?
Use `headingModule` for turnleft90 etc.

# Questions/notes for reviewers
I guess these aren't necessarily the best default PID constants and thresholds...

# How did you test this?
looked fine in sim.